### PR TITLE
#![rustfmt::skip] removed

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,0 +1,1 @@
+ignore = ["src/generated/*"]

--- a/src/common.rs
+++ b/src/common.rs
@@ -6,7 +6,6 @@
 #![allow(clippy::all)]
 
 #![allow(unused_attributes)]
-#![rustfmt::skip]
 
 #![allow(box_pointers)]
 #![allow(dead_code)]

--- a/src/data.rs
+++ b/src/data.rs
@@ -6,7 +6,6 @@
 #![allow(clippy::all)]
 
 #![allow(unused_attributes)]
-#![rustfmt::skip]
 
 #![allow(box_pointers)]
 #![allow(dead_code)]

--- a/src/debug.rs
+++ b/src/debug.rs
@@ -6,7 +6,6 @@
 #![allow(clippy::all)]
 
 #![allow(unused_attributes)]
-#![rustfmt::skip]
 
 #![allow(box_pointers)]
 #![allow(dead_code)]

--- a/src/error.rs
+++ b/src/error.rs
@@ -6,7 +6,6 @@
 #![allow(clippy::all)]
 
 #![allow(unused_attributes)]
-#![rustfmt::skip]
 
 #![allow(box_pointers)]
 #![allow(dead_code)]

--- a/src/query.rs
+++ b/src/query.rs
@@ -6,7 +6,6 @@
 #![allow(clippy::all)]
 
 #![allow(unused_attributes)]
-#![rustfmt::skip]
 
 #![allow(box_pointers)]
 #![allow(dead_code)]

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -6,7 +6,6 @@
 #![allow(clippy::all)]
 
 #![allow(unused_attributes)]
-#![rustfmt::skip]
 
 #![allow(box_pointers)]
 #![allow(dead_code)]

--- a/src/sc2api.rs
+++ b/src/sc2api.rs
@@ -6,7 +6,6 @@
 #![allow(clippy::all)]
 
 #![allow(unused_attributes)]
-#![rustfmt::skip]
 
 #![allow(box_pointers)]
 #![allow(dead_code)]

--- a/src/score.rs
+++ b/src/score.rs
@@ -6,7 +6,6 @@
 #![allow(clippy::all)]
 
 #![allow(unused_attributes)]
-#![rustfmt::skip]
 
 #![allow(box_pointers)]
 #![allow(dead_code)]

--- a/src/spatial.rs
+++ b/src/spatial.rs
@@ -6,7 +6,6 @@
 #![allow(clippy::all)]
 
 #![allow(unused_attributes)]
-#![rustfmt::skip]
 
 #![allow(box_pointers)]
 #![allow(dead_code)]

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -6,7 +6,6 @@
 #![allow(clippy::all)]
 
 #![allow(unused_attributes)]
-#![rustfmt::skip]
 
 #![allow(box_pointers)]
 #![allow(dead_code)]


### PR DESCRIPTION
#![rustfmt::skip] is not vital for the functionality and causes error in rust versions < 1.85.0. Removing it will allow us using stable version of rust